### PR TITLE
Bump pybind11 to the latest tag v3.0.0rc1

### DIFF
--- a/.github/actions/boost-cache/action.yml
+++ b/.github/actions/boost-cache/action.yml
@@ -29,7 +29,7 @@ runs:
     if: steps.cache-boost.outputs.cache-hit != 'true'
     shell: bash
     run: |
-      wget -qO- https://boostorg.jfrog.io/artifactory/main/release/1.${{ inputs.boost_minor }}.0/source/boost_1_${{ inputs.boost_minor }}_0.tar.bz2 | tar xjf -
+      wget -qO- https://archives.boost.io/release/1.${{ inputs.boost_minor }}.0/source/boost_1_${{ inputs.boost_minor }}_0.tar.bz2 | tar xjf -
       cd boost_1_${{ inputs.boost_minor }}_0
       ./bootstrap.sh
       ./b2 --prefix=../boost --with-serialization --with-filesystem --with-test install

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-15"]
+        os: ["ubuntu-latest", "macos-14"]
         boost_minor: [85]
 
     steps:

--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14"]
+        os: ["ubuntu-latest", "macos-15"]
         boost_minor: [85]
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install a wheel
       run: |
-        pip install --no-index --find-links file://$PWD/dist brain-indexer
+        pip install -find-links file://$PWD/dist --pre brain-indexer
 
     - name: Run integration
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install a wheel
       run: |
-        pip install --find-links file://$PWD/dist brain-indexer 
+        pip install --no-index --find-links file://$PWD/dist brain-indexer
 
     - name: Run integration
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Install a wheel
       run: |
-        pip install -find-links file://$PWD/dist --pre brain-indexer
+        pip install --find-links file://$PWD/dist --pre brain-indexer
 
     - name: Run integration
       run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,6 +34,10 @@ jobs:
         path: dist/
         merge-multiple: true
 
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: dist
+
     - name: Install a wheel
       run: |
         pip install --find-links file://$PWD/dist brain-indexer 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-15"]
+        os: ["ubuntu-latest", "macos-14"]
         boost_minor: [85]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14"]
+        os: ["ubuntu-latest", "macos-15"]
         boost_minor: [85]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,9 @@ jobs:
     needs: [cache_boost]
 
   publish:
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish.yml
     secrets: inherit
     needs: [cache_boost]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/setup-python@v5
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.18.1 twine
+      run: python -m pip install cibuildwheel twine
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/setup-python@v5
 
     - name: Install cibuildwheel
-      run: python -m pip install -U cibuildwheel==2.18.1 twine packaging
+      run: python -m pip install -U cibuildwheel twine packaging
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,20 +92,20 @@ jobs:
     - uses: actions/setup-python@v5
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel twine
+      run: python -m pip install -U cibuildwheel==2.18.1 twine packaging
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist
       env:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
 
-    - name: Verify wheels
-      run: python -m twine check dist/*
-
     - uses: actions/upload-artifact@v4
       with:
         name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
         path: ./dist/*.whl
+
+    - name: Verify wheels
+      run: python -m twine check dist/*
 
   publish:
     name: Publish package to PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/setup-python@v5
 
     - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel twine
+      run: python -m pip install cibuildwheel==2.18.1 twine
 
     - name: Build wheels
       run: python -m cibuildwheel --output-dir dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-15"]
+        os: ["ubuntu-latest", "macos-14"]
         boost_minor: [85]
         python-version: ['3.11', '3.12']
         toxenv: ['py3']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-latest", "macos-14"]
+        os: ["ubuntu-latest", "macos-15"]
         boost_minor: [85]
         python-version: ['3.11', '3.12']
         toxenv: ['py3']

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     post_checkout:
       - git submodule update --init
     post_install:
-      - wget -qO- https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
+      - wget -qO- https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
       - cd boost_1_85_0 && ./bootstrap.sh && ./b2 --prefix=../boost --with-serialization --with-filesystem --with-test install
       - env CMAKE_PREFIX_PATH=boost SKBUILD_CMAKE_DEFINE="CMAKE_INSTALL_RPATH=$PWD/boost/lib;SI_MPI=OFF" pip install .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:latest
 
 RUN apt-get update \
  && apt-get install -y libopenmpi-dev
-RUN wget -qO- https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf - \
+RUN wget -qO- https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf - \
  && cd boost_1_85_0 \
  && ./bootstrap.sh \
  && ./b2 --prefix=/opt/boost --with-serialization --with-filesystem --with-test install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ brain-indexer requires Boost with a minimum version of 1.79.0, but preferably 1.
 newer.  If your system does not provide such a version, one can install a more recent one
 into `/opt/boost/` as follows:
 ```console
-wget -qO- https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
+wget -qO- https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
 cd boost_1_85_0
 ./bootstrap.sh
 ./b2 --prefix=/opt/boost --with-serialization --with-filesystem --with-test install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "brain-indexer"
 description = "A spatial index implementation for spheres, morphologies and synapses"
 readme = "README.md"
 authors = [{ name="Blue Brain Project", email = "bbp-ou-hpc@epfl.ch" } ]
-license = {"file" = "LICENSE.txt"}
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 # maintainer is the field chosen for docs `contributors`
 maintainers = [{name="Fernando Pereira"}, {name="Antonio Bellotta"}, {name="Luc Dominic Grosheintz-Laval"}]
 dynamic = ["version"]
@@ -12,8 +13,7 @@ classifiers = [
    "Development Status :: 3 - Alpha",
    "Programming Language :: C++",
    "Programming Language :: Python",
-   "Topic :: Scientific/Engineering",
-   "License :: OSI Approved :: Apache Software License",
+   "Topic :: Scientific/Engineering"
 ]
 requires-python = ">=3.9"
 dependencies = ["numpy>=1.13.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,7 @@ name = "brain-indexer"
 description = "A spatial index implementation for spheres, morphologies and synapses"
 readme = "README.md"
 authors = [{ name="Blue Brain Project", email = "bbp-ou-hpc@epfl.ch" } ]
-license = "Apache-2.0"
-license-files = ["LICENSE.txt"]
+license = {"file" = "LICENSE.txt"}
 # maintainer is the field chosen for docs `contributors`
 maintainers = [{name="Fernando Pereira"}, {name="Antonio Bellotta"}, {name="Luc Dominic Grosheintz-Laval"}]
 dynamic = ["version"]
@@ -13,7 +12,8 @@ classifiers = [
    "Development Status :: 3 - Alpha",
    "Programming Language :: C++",
    "Programming Language :: Python",
-   "Topic :: Scientific/Engineering"
+   "Topic :: Scientific/Engineering",
+   "License :: OSI Approved :: Apache Software License",
 ]
 requires-python = ">=3.9"
 dependencies = ["numpy>=1.13.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ test-command = ["python -m pytest {project}/tests"]
 [tool.cibuildwheel.linux]
 before-all = """
 yum install -y wget
-wget -qO- https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
+wget -qO- https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.bz2 | tar xjf -
 cd boost_1_85_0
 ./bootstrap.sh
 ./b2 --prefix=/opt/boost --with-serialization --with-filesystem --with-test install

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ endfunction()
 
 function(SI_MPI_UNIT_TEST test_src)
     si_unit_test_build(${test_src})
-    add_test(NAME ${test_src} COMMAND ${${PROJECT}_MPIEXEC} ${${PROJECT}_MPIEXEC_NPROC_FLAG} 4 "${CMAKE_CURRENT_BINARY_DIR}/${test_src}")
+    add_test(NAME ${test_src} COMMAND ${${PROJECT}_MPIEXEC} ${${PROJECT}_MPIEXEC_NPROC_FLAG} 2 "${CMAKE_CURRENT_BINARY_DIR}/${test_src}")
 endfunction()
 
 function(SI_CPP_EXAMPLE test_src)

--- a/tests/cpp/test_serial_sort_tile_recursion.cpp
+++ b/tests/cpp/test_serial_sort_tile_recursion.cpp
@@ -203,7 +203,7 @@ std::vector<Value> random_values(size_t n_values,
 
 
 BOOST_AUTO_TEST_CASE(DistributedSTRTests) {
-    int n_required_ranks = 4;
+    int n_required_ranks = 2;
     auto comm = mpi::comm_shrink(MPI_COMM_WORLD, n_required_ranks);
 
     if(*comm == comm.invalid_handle()) {
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(DistributedSTRTests) {
     auto domain = std::array<float, 2>{-1.0, 1.0};
     auto values = random_values(n_initial_values, domain, comm_rank);
 
-    auto distr_params = DistributedSTRParams{comm_size * n_initial_values, {2, 2, 1}};
+    auto distr_params = DistributedSTRParams{comm_size * n_initial_values, {1, 2, 1}};
     distributed_sort_tile_recursion<Value, GetCoordFromValue>(values, distr_params, *comm);
 
 

--- a/tests/cpp/test_serial_sort_tile_recursion.cpp
+++ b/tests/cpp/test_serial_sort_tile_recursion.cpp
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(DistributedSTRTests) {
     auto domain = std::array<float, 2>{-1.0, 1.0};
     auto values = random_values(n_initial_values, domain, comm_rank);
 
-    auto distr_params = DistributedSTRParams{comm_size * n_initial_values, {1, 2, 1}};
+    auto distr_params = DistributedSTRParams{comm_size * n_initial_values, rank_distribution(comm_size)};
     distributed_sort_tile_recursion<Value, GetCoordFromValue>(values, distr_params, *comm);
 
 


### PR DESCRIPTION
fix #1 
- Update pybind11 to tag v3.0.0rc1
- Update boost download link
- Use 2 processes for the ctest due to the available CPU cores for GitHub MacOS-14 runner
- Declare licenses in pyproject.toml as per PEP 639
- Fix pipelines regarding building wheels and testing the built wheel 