### PR TITLE
Fix compilation on newer macos environment

### DIFF
--- a/include/brain_indexer/detail/input_iterators.hpp
+++ b/include/brain_indexer/detail/input_iterators.hpp
@@ -19,7 +19,12 @@ struct indexed_iterator_base {
     size_t i_;
     inline CRT& operator+=(size_t i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
     inline CRT& operator-=(size_t i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
-    inline CRT& operator+(size_t i) && noexcept { return (*this)+=i; }
+    //inline CRT& operator+(size_t i) && noexcept { return (*this)+=i; }
+    inline CRT operator+(size_t i) const noexcept {
+        CRT tmp = static_cast<const CRT&>(*this);
+        tmp += i;
+        return tmp;
+    }
     inline CRT& operator-(size_t i) && noexcept { return (*this)+=i; }
     inline CRT& operator++() noexcept { return (*this)+=1; }
     inline CRT& operator--() noexcept { return (*this)-=1; }

--- a/include/brain_indexer/detail/input_iterators.hpp
+++ b/include/brain_indexer/detail/input_iterators.hpp
@@ -11,27 +11,37 @@ namespace detail {
 template <typename CRT, typename ValueT>
 struct indexed_iterator_base {
     using iterator_category = std::random_access_iterator_tag;
-    using difference_type   = size_t;
+    using difference_type   = std::ptrdiff_t;
     using value_type        = ValueT;
     using reference         = const ValueT&;  // Support Temporaries
     using pointer           = ValueT*;
 
     size_t i_;
-    inline CRT& operator+=(size_t i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
-    inline CRT& operator-=(size_t i) noexcept { i_ -= i; return *static_cast<CRT*>(this); }
-    inline CRT operator+(size_t i) const noexcept {
+
+    /* i_ is unsigned type, as it is an index.
+     * difference_type is signed, as recommended in the docs.
+     * The standard allows negative values for iterator arithmetic in in random access iterators,
+     * therefore we need to use a signed type (std::ptrdiff_t) in +=, -=, + and - operators.
+     * We also need to be careful when doing arithmetic operations with i_, as it can result in
+     * a negative value, which could still be correct (e.g. -3 positions from end()).
+     * Therefore, we need to convert i_ to a signed type in operator- function.
+     */
+
+    inline CRT& operator+=(difference_type i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
+    inline CRT& operator-=(difference_type i) noexcept { i_ -= i; return *static_cast<CRT*>(this); }
+    inline CRT operator+(difference_type i) const noexcept {
         CRT tmp = static_cast<const CRT&>(*this);
         tmp += i;
         return tmp;
     }
-    inline CRT operator-(size_t i) const noexcept {
+    inline CRT operator-(difference_type i) const noexcept {
         CRT tmp = static_cast<const CRT&>(*this);
         tmp -= i;
         return tmp;
     }
     inline CRT& operator++() noexcept { return (*this)+=1; }
     inline CRT& operator--() noexcept { return (*this)-=1; }
-    inline difference_type operator-(const CRT& rhs) const noexcept { return i_ - rhs.i_; }
+    inline difference_type operator-(const CRT& rhs) const noexcept { return (difference_type)i_ - (difference_type)rhs.i_; }
     inline bool operator==(const CRT& rhs) const noexcept { return i_ == rhs.i_; }
     inline bool operator!=(const CRT& rhs) const noexcept  { return i_ != rhs.i_; }
     inline bool operator<(const CRT& rhs) const noexcept  { return i_ < rhs.i_; }

--- a/include/brain_indexer/detail/input_iterators.hpp
+++ b/include/brain_indexer/detail/input_iterators.hpp
@@ -41,7 +41,7 @@ struct indexed_iterator_base {
     }
     inline CRT& operator++() noexcept { return (*this)+=1; }
     inline CRT& operator--() noexcept { return (*this)-=1; }
-    inline difference_type operator-(const CRT& rhs) const noexcept { return (difference_type)i_ - (difference_type)rhs.i_; }
+    inline difference_type operator-(const CRT& rhs) const noexcept { return static_cast<difference_type>(i_) - static_cast<difference_type>(rhs.i_); }
     inline bool operator==(const CRT& rhs) const noexcept { return i_ == rhs.i_; }
     inline bool operator!=(const CRT& rhs) const noexcept  { return i_ != rhs.i_; }
     inline bool operator<(const CRT& rhs) const noexcept  { return i_ < rhs.i_; }

--- a/include/brain_indexer/detail/input_iterators.hpp
+++ b/include/brain_indexer/detail/input_iterators.hpp
@@ -18,20 +18,26 @@ struct indexed_iterator_base {
 
     size_t i_;
     inline CRT& operator+=(size_t i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
-    inline CRT& operator-=(size_t i) noexcept { i_ += i; return *static_cast<CRT*>(this); }
-    //inline CRT& operator+(size_t i) && noexcept { return (*this)+=i; }
+    inline CRT& operator-=(size_t i) noexcept { i_ -= i; return *static_cast<CRT*>(this); }
     inline CRT operator+(size_t i) const noexcept {
         CRT tmp = static_cast<const CRT&>(*this);
         tmp += i;
         return tmp;
     }
-    inline CRT& operator-(size_t i) && noexcept { return (*this)+=i; }
+        inline CRT operator-(size_t i) const noexcept {
+        CRT tmp = static_cast<const CRT&>(*this);
+        tmp -= i;
+        return tmp;
+    }
     inline CRT& operator++() noexcept { return (*this)+=1; }
     inline CRT& operator--() noexcept { return (*this)-=1; }
     inline difference_type operator-(const CRT& rhs) const noexcept { return i_ - rhs.i_; }
     inline bool operator==(const CRT& rhs) const noexcept { return i_ == rhs.i_; }
     inline bool operator!=(const CRT& rhs) const noexcept  { return i_ != rhs.i_; }
     inline bool operator<(const CRT& rhs) const noexcept  { return i_ < rhs.i_; }
+    inline bool operator<=(const CRT& rhs) const noexcept  { return i_ <= rhs.i_; }
+    inline bool operator>(const CRT& rhs) const noexcept  { return i_ > rhs.i_; }
+    inline bool operator>=(const CRT& rhs) const noexcept  { return i_ >= rhs.i_; }
 
     // get(size_t i);  // To be implemented in subclass
     // Note: we use decltype because get() may return by value, by [const]ref...

--- a/include/brain_indexer/detail/input_iterators.hpp
+++ b/include/brain_indexer/detail/input_iterators.hpp
@@ -24,7 +24,7 @@ struct indexed_iterator_base {
         tmp += i;
         return tmp;
     }
-        inline CRT operator-(size_t i) const noexcept {
+    inline CRT operator-(size_t i) const noexcept {
         CRT tmp = static_cast<const CRT&>(*this);
         tmp -= i;
         return tmp;

--- a/tests/cpp/test_input_iters.cpp
+++ b/tests/cpp/test_input_iters.cpp
@@ -44,12 +44,12 @@ BOOST_AUTO_TEST_CASE(SOA_Reader) {
 }
 
 
-BOOST_AUTO_TEST_CASE(SOA_Iterator) {
+BOOST_AUTO_TEST_CASE(SOA_Iterator_forward) {
     struct S { int a, b; };
     std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
     auto soa = util::make_soa_reader<S>(v1, v2);
 
-    int i=0;
+    int i = 0;
     for(auto iter=soa.begin(); iter < soa.end(); ++iter, i++) {
         const auto item = *iter;
         BOOST_TEST(item.a == v1[i]);
@@ -58,12 +58,97 @@ BOOST_AUTO_TEST_CASE(SOA_Iterator) {
     BOOST_TEST( i == 4 );
 
     // Awesome range loops
-    i=0;
+    i = 0;
     for(auto item : soa) {
         BOOST_TEST(item.a == v1[i]);
         BOOST_TEST(item.b == v2[i]);
         i++;
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(SOA_Iterator_backward) {
+    struct S { int a, b; };
+    std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
+    auto soa = util::make_soa_reader<S>(v1, v2);
+
+    int i = soa.size() - 1;
+    for(auto iter = soa.end() - 1; iter > soa.begin(); --iter, i--) {
+        const auto item = *iter;
+        BOOST_TEST(item.a == v1[i]);
+        BOOST_TEST(item.b == v2[i]);
+    }
+    BOOST_TEST(i == 0);
+}
+
+
+BOOST_AUTO_TEST_CASE(SOA_Iterator_arithmetic) {
+    struct S { int a, b; };
+    //std::vector<int> v1{1, 2, 3, 4, 5, 6, 7, 8}, v2{10, 20, 30, 40, 50, 60, 70, 80};
+    std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
+    auto soa = util::make_soa_reader<S>(v1, v2);
+
+    // operator+
+    auto iter1 = soa.begin();
+    auto iter2 = iter1 + 3;
+    BOOST_TEST((*iter2).a == 4);
+    BOOST_TEST((*iter2).b == 8);
+
+    // operator+=
+    auto iter3 = soa.begin();
+    iter3 += 2;
+    BOOST_TEST((*iter3).a == 3);
+    BOOST_TEST((*iter3).b == 7);
+
+    // operator-
+    auto iter4 = soa.begin() + 3;
+    auto iter5 = iter4 - 2;
+    BOOST_TEST((*iter5).a == 2);
+    BOOST_TEST((*iter5).b == 6);
+
+    // operator-=
+    auto iter6 = soa.begin() + 3;
+    iter6 -= 2;
+    BOOST_TEST((*iter6).a == 2);
+    BOOST_TEST((*iter6).b == 6);
+
+    // operator--
+    auto iter7 = soa.begin() + 3;
+    --iter7;
+    BOOST_TEST((*iter7).a == 3);
+    BOOST_TEST((*iter7).b == 7);
+
+    // operator==
+    auto iter10 = soa.begin() + 2;
+    auto iter11 = soa.end() - 2;
+    bool eq_result = (iter10 == iter11);
+    BOOST_TEST(eq_result == true);
+
+    // operator!=
+    auto iter12 = soa.begin();
+    auto iter13 = soa.begin() + 1;
+    bool neq_result = (iter12 != iter13);
+    BOOST_TEST(neq_result == true);
+
+    // operator<
+    bool lt_result = (soa.begin() < soa.end());
+    BOOST_TEST(lt_result == true);
+
+    // operator<=
+    bool lte_result1 = (soa.begin() <= soa.end());
+    BOOST_TEST(lte_result1 == true);
+    bool lte_result2 = (soa.begin() <= soa.begin());
+    BOOST_TEST(lte_result2 == true);
+
+    // operator>
+    bool gt_result = (soa.end() > soa.begin());
+    BOOST_TEST(gt_result == true);
+
+    // operator>=
+    bool gte_result1 = (soa.end() >= soa.begin());
+    BOOST_TEST(gte_result1 == true);
+    bool gte_result2 = (soa.begin() >= soa.begin());
+    BOOST_TEST(gte_result2 == true);
 }
 
 

--- a/tests/cpp/test_input_iters.cpp
+++ b/tests/cpp/test_input_iters.cpp
@@ -84,7 +84,6 @@ BOOST_AUTO_TEST_CASE(SOA_Iterator_backward) {
 
 BOOST_AUTO_TEST_CASE(SOA_Iterator_arithmetic) {
     struct S { int a, b; };
-    //std::vector<int> v1{1, 2, 3, 4, 5, 6, 7, 8}, v2{10, 20, 30, 40, 50, 60, 70, 80};
     std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
     auto soa = util::make_soa_reader<S>(v1, v2);
 

--- a/tests/cpp/test_input_iters.cpp
+++ b/tests/cpp/test_input_iters.cpp
@@ -148,6 +148,45 @@ BOOST_AUTO_TEST_CASE(SOA_Iterator_arithmetic) {
     BOOST_TEST(gte_result1 == true);
     bool gte_result2 = (soa.begin() >= soa.begin());
     BOOST_TEST(gte_result2 == true);
+
+    // operator[] subscript
+    auto iter14 = soa.begin() + 1;
+    BOOST_TEST(iter14[0].a == 2);
+    BOOST_TEST(iter14[2].a == 4);
+
+    /* Checks for signed difference_type vs unsigned size_t */
+    // iterator difference (positive)
+    auto diff1 = (soa.begin() + 3) - soa.begin();
+    BOOST_TEST(diff1 == 3);
+
+    // iterator difference (negative)
+    auto diff2 = soa.begin() - (soa.begin() + 2);
+    BOOST_TEST(diff2 == -2);
+
+    // negative offsets with operator+
+    auto iter15 = soa.begin() + 3;
+    auto iter16 = iter15 + (-2);
+    BOOST_TEST((*iter16).a == 2);
+    BOOST_TEST((*iter16).b == 6);
+
+    // negative offsets with operator+=
+    auto iter17 = soa.begin() + 3;
+    iter17 += -1;
+    BOOST_TEST((*iter17).a == 3);
+    BOOST_TEST((*iter17).b == 7);
+
+    // negative offsets with operator- (should move forward)
+    auto iter18 = soa.begin() + 1;
+    auto iter19 = iter18 - (-2);
+    BOOST_TEST((*iter19).a == 4);
+    BOOST_TEST((*iter19).b == 8);
+
+    // negative offsets with operator-= (should move forward)
+    auto iter20 = soa.begin() + 1;
+    iter20 -= -2;
+    BOOST_TEST((*iter20).a == 4);
+    BOOST_TEST((*iter20).b == 8);
+
 }
 
 

--- a/tests/cpp/test_input_iters.cpp
+++ b/tests/cpp/test_input_iters.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(SOA_Iterator_forward) {
     std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
     auto soa = util::make_soa_reader<S>(v1, v2);
 
-    int i = 0;
+    size_t i = 0;
     for(auto iter=soa.begin(); iter < soa.end(); ++iter, i++) {
         const auto item = *iter;
         BOOST_TEST(item.a == v1[i]);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(SOA_Iterator_backward) {
     std::vector<int> v1{1, 2, 3, 4}, v2{5, 6, 7, 8};
     auto soa = util::make_soa_reader<S>(v1, v2);
 
-    int i = soa.size() - 1;
+    size_t i = soa.size() - 1;
     for(auto iter = soa.end() - 1; iter > soa.begin(); --iter, i--) {
         const auto item = *iter;
         BOOST_TEST(item.a == v1[i]);


### PR DESCRIPTION
Fix compilation error on new macos environment:

```
      /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/copy_n.h:55:37: fatal error: invalid operands to binary expression
      ('brain_indexer::detail::SoA_Iterator<brain_indexer::util::SoA<brain_indexer::Synapse, const pybind11::detail::unchecked_reference<unsigned long, 1>, const
      pybind11::detail::unchecked_reference<unsigned long, 1>, const pybind11::detail::unchecked_reference<unsigned long, 1>, const boost::geometry::model::point<float,
      3, boost::geometry::cs::cartesian> *const>>' and 'difference_type' (aka 'unsigned long'))
         55 |   return std::copy(__first, __first + difference_type(__n), __result);
            |                             ~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~
```