### PR TITLE
MPI should be optional when installing through pip from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ minimum-version = "3.5.0"
 
 [tool.scikit-build.cmake.define]
 SI_UNIT_TESTS="OFF"
+SI_MPI="OFF"
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Disable MPI by default when installing through pip from source